### PR TITLE
ensure storing execution time when rescuing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Ensure `execution_time_in_ms` is stored when checks are failing, [#11](https://github.com/dbl-works/checker/pull/11)
 
 
 


### PR DESCRIPTION
fixes https://github.com/dbl-works/checker/issues/8﻿
